### PR TITLE
Add proposition for database schema sharing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -26,3 +26,6 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# do not commit database connection details
+database.properties

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,9 @@
+postgres:
+  image: postgres:latest
+  environment:
+    - POSTGRES_USER=postgres
+    - POSTGRES_PASSWORD=secret
+  ports:
+    - 5436:5432
+  volumes:
+    - ./var/database/database.sql:/docker-entrypoint-initdb.d/database.sql

--- a/src/main/resources/database.properties.example
+++ b/src/main/resources/database.properties.example
@@ -1,0 +1,4 @@
+javabase.jdbc.url = jdbc:postgresql://localhost:5432/postgres
+javabase.jdbc.driver = org.postgresql.Driver
+javabase.jdbc.username = postgres
+javabase.jdbc.password = secret

--- a/var/database/database.sql
+++ b/var/database/database.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS books (
+    id bigserial NOT NULL,
+		name VARCHAR(500) NOT NULL,
+
+    PRIMARY KEY (id),
+    UNIQUE (id)
+);


### PR DESCRIPTION
Предложение по работе с бд, как минимум пока не разобрались с миграциями. 

- Файл `var/database/database.sql`  содержит образец схемы 
- С помощью команды `docker-compose up -d` создается и запускается контейнер с инстансом postgres и внутри выполняется sql из указанного файла.

Таким образом мы имеем простую возможность вносить изменения в базу и шарить схему (просто внося изменения в sql файл). Для работы любому пользователю достаточно убить контейнер (если запущен) `docker-compose kill` и заново выполнить команду запуска предварительно обновив sql файл командой git pull из репозитория.

Никаких дополнительных шагов для поддержки не нужно. Также не нужно иметь локально запущенную базу на своей машине. Необходимо иметь установленный и настроенный docker / docker-compose.